### PR TITLE
Fix iPhone alignment on train name text

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -100,6 +100,7 @@ html, body {
   background-color: transparent;
   padding-top: 4px;
   font-weight: bold;
+  line-height: 1.2;
 }
 
 .status {
@@ -183,6 +184,7 @@ a { color: white }
   .letter {
     width: 75px;
     font-size: 52px;
+    line-height: normal;
   }
 
   .status {


### PR DESCRIPTION
Fixes #21 alignment issue on iPhones by explicitly defining line height. Tested on a iPhone 6 running iOS 9.3 on Safari and Google Chrome 54. Line height adjusted to match perfectly with height displayed on mobile version on Chrome, having no side effect if disabled.  Also works if viewed as a home screen app.
No effect on desktop view, thanks to `line-height: normal;`.

| Before | After |
| :-: | :-: |
| ![](http://i.imgur.com/TIHEb5D.png) | ![](http://i.imgur.com/lnvYvPT.png) |

_Orange color is due to having night mode on._
